### PR TITLE
Remove white background from instructions for proper contrast on dark theme

### DIFF
--- a/style.css
+++ b/style.css
@@ -4,7 +4,6 @@
     font-size: 15px;
     margin: 10px;
     padding: 10px;
-    background-color: white;
 }
 
 #ebs_configuration_tab1>div{


### PR DESCRIPTION
When using dark theme, the instructions are barely visible:

![image](https://user-images.githubusercontent.com/7556242/233591303-ea44a869-5c4d-4a55-adf4-2c4a9f6fef18.png)

This is due to the styles forcing a white background. Just removing it fixes it for light and dark themes:

![image](https://user-images.githubusercontent.com/7556242/233591524-f7995495-aedf-4372-b6fc-43b4c60588d8.png)
![image](https://user-images.githubusercontent.com/7556242/233591594-b79a6796-5548-404d-83a2-59a5f07c4f49.png)

To test this, add `?__theme=dark` or `?__theme=light` to your Automatic1111 URL