### PR TITLE
If the path of the virtual environment is not venv, it will crashed when call transparent_background

### DIFF
--- a/stage1.py
+++ b/stage1.py
@@ -147,7 +147,8 @@ def create_mask_clipseg(input_dir, output_dir, clipseg_mask_prompt, clipseg_excl
 def create_mask_transparent_background(input_dir, output_dir, tb_use_fast_mode, tb_use_jit, st1_mask_threshold):
     fast_str = " --fast" if tb_use_fast_mode else ""
     jit_str = " --jit" if tb_use_jit else ""
-    bin_path = os.path.join("venv", "Scripts")
+    venv = os.environ['VIRTUAL_ENV']
+    bin_path = os.path.join(venv, "Scripts")
     bin_path = os.path.join(bin_path, "transparent-background")
 
     if os.path.isfile(bin_path) or os.path.isfile(bin_path + ".exe"):


### PR DESCRIPTION
If the path of the virtual environment is not "venv", it will crash when call transparent_background,  This modification replace the "venv" with the value of environment variable "VIRTUAL_ENV"