### PR TITLE
closes #121 regarding dependency installations on M1/M2 Macs

### DIFF
--- a/install.py
+++ b/install.py
@@ -1,4 +1,5 @@
 import launch
+import platform
 
 def update_transparent_background():
     from importlib.metadata import version as meta_version
@@ -7,6 +8,12 @@ def update_transparent_background():
     print("current transparent-background " + v)
     if version.parse(v) < version.parse('1.2.3'):
         launch.run_pip("install -U transparent-background", "update transparent-background version for Ebsynth Utility")
+
+# Check if user is running an M1/M2 device and, if so, install pyvirtualcam, which is required for updating the transparent_background package
+# Note that we have to directly install from source because the prebuilt PyPl wheel does not support ARM64 machines such as M1/M2 Macs
+if platform.system() == "Darwin" and platform.machine() == "arm64":
+    if not launch.is_installed("pyvirtualcam"):
+        launch.run_pip("install git+https://github.com/letmaik/pyvirtualcam", "requirements for Ebsynth Utility")
 
 if not launch.is_installed("transparent_background"):
     launch.run_pip("install transparent-background", "requirements for Ebsynth Utility")


### PR DESCRIPTION
Closes https://github.com/s9roll7/ebsynth_utility/issues/121.

Extension now works properly on M1/M2 Mac devices. Fixed bug regarding M1/M2 not being able to update transparent_background package during installation because the pyvirtualcam dependency fails to install.