### PR TITLE
Update stage1.py

### DIFF
--- a/stage1.py
+++ b/stage1.py
@@ -148,7 +148,8 @@ def create_mask_clipseg(input_dir, output_dir, clipseg_mask_prompt, clipseg_excl
 
 def create_mask_transparent_background(input_dir, output_dir, tb_use_fast_mode, tb_use_jit, st1_mask_threshold):
     from modules import devices
-    remover = Remover(fast=tb_use_fast_mode, jit=tb_use_jit, device=devices.get_optimal_device_name())
+    mode='fast' if tb_use_fast_mode else 'base'
+    remover = Remover(mode=mode, jit=tb_use_jit, device=devices.get_optimal_device_name())
 
     original_imgs = glob.glob( os.path.join(input_dir, "*.png") )
 


### PR DESCRIPTION
Since the version of transparent_backgound updates, the 'fast' keyword is no longer used. Instead, it is replaced by 'mode' which supports 'base', 'fast' and 'base-nightly'